### PR TITLE
chore: update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/github": "^1.1.0",
-    "@technote-space/filter-github-action": "^0.1.10",
-    "@technote-space/github-action-helper": "^0.6.0"
+    "@technote-space/filter-github-action": "^0.1.11",
+    "@technote-space/github-action-helper": "^0.6.4"
   },
   "devDependencies": {
     "@technote-space/github-action-test-helper": "^0.0.25",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "@technote-space/github-action-helper": "^0.6.0"
   },
   "devDependencies": {
-    "@technote-space/github-action-test-helper": "^0.0.24",
+    "@technote-space/github-action-test-helper": "^0.0.25",
     "@types/jest": "^24.0.23",
-    "@types/node": "^12.12.12",
-    "@typescript-eslint/eslint-plugin": "^2.8.0",
-    "@typescript-eslint/parser": "^2.8.0",
+    "@types/node": "^12.12.14",
+    "@typescript-eslint/eslint-plugin": "^2.9.0",
+    "@typescript-eslint/parser": "^2.9.0",
     "eslint": "^6.7.1",
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@technote-space/github-action-helper": "^0.6.0"
   },
   "devDependencies": {
-    "@technote-space/github-action-test-helper": "^0.0.22",
+    "@technote-space/github-action-test-helper": "^0.0.24",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.12",
     "@typescript-eslint/eslint-plugin": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^12.12.12",
     "@typescript-eslint/eslint-plugin": "^2.8.0",
     "@typescript-eslint/parser": "^2.8.0",
-    "eslint": "^6.7.0",
+    "eslint": "^6.7.1",
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "nock": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@actions/core": "^1.2.0",
     "@actions/github": "^1.1.0",
     "@technote-space/filter-github-action": "^0.1.11",
-    "@technote-space/github-action-helper": "^0.6.4"
+    "@technote-space/github-action-helper": "^0.6.8"
   },
   "devDependencies": {
     "@technote-space/github-action-test-helper": "^0.0.25",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@actions/core": "^1.2.0",
     "@actions/github": "^1.1.0",
     "@technote-space/filter-github-action": "^0.1.11",
-    "@technote-space/github-action-helper": "^0.6.8"
+    "@technote-space/github-action-helper": "^0.6.9"
   },
   "devDependencies": {
     "@technote-space/github-action-test-helper": "^0.0.25",
@@ -30,7 +30,7 @@
     "@types/node": "^12.12.14",
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",
-    "eslint": "^6.7.1",
+    "eslint": "^6.7.2",
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "nock": "^11.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
   dependencies:
     "@actions/github" "^1.1.0"
 
-"@technote-space/github-action-helper@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.4.tgz#a85f580f8474a7e1c1e69979f4146e9991baf512"
-  integrity sha512-RkDNz/MIWa1pShCYPJS+dm6KhPav3BcogVJdSqo+jEo4muZrbpvp2cvsoiJQcp6BAOFa9hK+9Am79B9Sq4pGHQ==
+"@technote-space/github-action-helper@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.8.tgz#f332a5966710828b40d854ec54bcffe80f790b27"
+  integrity sha512-oRQfPOQYwkbRfiK6p/ykFKXDetVbcE6BGGI9oRyQ4FjKffUUxQHAqnol8zoEkWliCPO8j+3TDv1bB/1w7Yy1ZQ==
   dependencies:
     "@actions/core" "^1.2.0"
     "@actions/github" "^1.1.0"
@@ -3304,9 +3304,9 @@ propagate@^2.0.0:
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 psl@^1.1.24, psl@^1.1.28:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
-  integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.5.0.tgz#47fd1292def7fdb1e138cd78afa8814cebcf7b13"
+  integrity sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -4105,9 +4105,9 @@ typescript@^3.7.2:
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.0.tgz#14b854003386b7a7c045910f43afbc96d2aa5307"
-  integrity sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.1.tgz#35c7de17971a4aa7689cd2eae0a5b39bb838c0c5"
+  integrity sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
     "@actions/github" "^1.1.0"
     sprintf-js "^1.1.2"
 
-"@technote-space/github-action-test-helper@^0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.0.24.tgz#c659348513372971d0edb2d91d9e9c53faa15560"
-  integrity sha512-t7yR7nNKAHMBgigTpKI0QiHZZgS0fUmdED2fkzVOLaeGvnuNAzd6M4d7gmcIiWi7NYRYNjFAq0LkNt0vyI7u+w==
+"@technote-space/github-action-test-helper@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.0.25.tgz#990375bbe2584991b3553152b043118492e139de"
+  integrity sha512-b6ZdV21BzyXkzUfdrGbBaXOu+r3qW9qVN4fVPDktIkelbMcrXXMNS2AEUOKaB3s1woA4Wd5b0JqxIaF72o97og==
   dependencies:
     "@actions/github" "^1.1.0"
     js-yaml "^3.13.1"
@@ -458,10 +458,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/node@>= 8", "@types/node@^12.12.12":
-  version "12.12.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.12.tgz#529bc3e73dbb35dd9e90b0a1c83606a9d3264bdb"
-  integrity sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ==
+"@types/node@>= 8", "@types/node@^12.12.14":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -480,40 +480,40 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.8.0.tgz#eca584d46094ebebc3cb3e9fb625bfbc904a534d"
-  integrity sha512-ohqul5s6XEB0AzPWZCuJF5Fd6qC0b4+l5BGEnrlpmvXxvyymb8yw8Bs4YMF8usNAeuCJK87eFIHy8g8GFvOtGA==
+"@typescript-eslint/eslint-plugin@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.9.0.tgz#fa810282c0e45f6c2310b9c0dfcd25bff97ab7e9"
+  integrity sha512-98rfOt3NYn5Gr9wekTB8TexxN6oM8ZRvYuphPs1Atfsy419SDLYCaE30aJkRiiTCwGEY98vOhFsEVm7Zs4toQQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.8.0"
+    "@typescript-eslint/experimental-utils" "2.9.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz#208b4164d175587e9b03ce6fea97d55f19c30ca9"
-  integrity sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==
+"@typescript-eslint/experimental-utils@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.9.0.tgz#bbe99a8d9510240c055fc4b17230dd0192ba3c7f"
+  integrity sha512-0lOLFdpdJsCMqMSZT7l7W2ta0+GX8A3iefG3FovJjrX+QR8y6htFlFdU7aOVPL6pDvt6XcsOb8fxk5sq+girTw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.8.0"
+    "@typescript-eslint/typescript-estree" "2.9.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.8.0.tgz#e10f7c40c8cf2fb19920c879311e6c46ad17bacb"
-  integrity sha512-NseXWzhkucq+JM2HgqAAoKEzGQMb5LuTRjFPLQzGIdLthXMNUfuiskbl7QSykvWW6mvzCtYbw1fYWGa2EIaekw==
+"@typescript-eslint/parser@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.9.0.tgz#2e9cf438de119b143f642a3a406e1e27eb70b7cd"
+  integrity sha512-fJ+dNs3CCvEsJK2/Vg5c2ZjuQ860ySOAsodDPwBaVlrGvRN+iCNC8kUfLFL8cT49W4GSiLPa/bHiMjYXA7EhKQ==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.8.0"
-    "@typescript-eslint/typescript-estree" "2.8.0"
+    "@typescript-eslint/experimental-utils" "2.9.0"
+    "@typescript-eslint/typescript-estree" "2.9.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz#fcc3fe6532840085d29b75432c8a59895876aeca"
-  integrity sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==
+"@typescript-eslint/typescript-estree@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.9.0.tgz#09138daf8f47d0e494ba7db9e77394e928803017"
+  integrity sha512-v6btSPXEWCP594eZbM+JCXuFoXWXyF/z8kaSBSdCb83DF+Y7+xItW29SsKtSULgLemqJBT+LpT+0ZqdfH7QVmA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -3496,9 +3496,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.2.tgz#08b12496d9aa8659c75f534a8f05f0d892fff594"
-  integrity sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.0.tgz#e879eb397efb40511056ede7300b6ac28c51290b"
+  integrity sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==
   dependencies:
     path-parse "^1.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,22 +1234,22 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.0.tgz#d3a26dc9c3283ac9750dca569586e976d9dcc06d"
-  integrity sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.2.tgz#4e874331645e9925edef141e74fc4bd144669d34"
+  integrity sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
   dependencies:
-    es-to-primitive "^1.2.0"
+    es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.0"
+    has-symbols "^1.0.1"
     is-callable "^1.1.4"
     is-regex "^1.0.4"
-    object-inspect "^1.6.0"
+    object-inspect "^1.7.0"
     object-keys "^1.1.1"
     string.prototype.trimleft "^2.1.0"
     string.prototype.trimright "^2.1.0"
 
-es-to-primitive@^1.2.0:
+es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
@@ -1295,10 +1295,10 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.0.tgz#766162e383b236e61d873697f82c3a3e41392020"
-  integrity sha512-dQpj+PaHKHfXHQ2Imcw5d853PTvkUGbHk/MR68KQUl98EgKDCdh4vLRH1ZxhqeQjQFJeg8fgN0UwmNhN3l8dDQ==
+eslint@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.1.tgz#269ccccec3ef60ab32358a44d147ac209154b919"
+  integrity sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -1718,7 +1718,7 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -3036,7 +3036,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.6.0:
+object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
@@ -4105,9 +4105,9 @@ typescript@^3.7.2:
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.9.tgz#85d353edb6ddfb62a9d798f36e91792249320611"
-  integrity sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.0.tgz#14b854003386b7a7c045910f43afbc96d2aa5307"
+  integrity sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,12 +380,13 @@
     "@actions/github" "^1.1.0"
     sprintf-js "^1.1.2"
 
-"@technote-space/github-action-test-helper@^0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.0.22.tgz#a1ad9a85ebb29951b7d85beab3731738f7bfefe9"
-  integrity sha512-Atjn+D2s0wJBllfjJ3lzrVoLVU2ssbOLWD8bIA7Id2e6iOKmVCwhhmfpvNLAP9l79xlr8zQIv+kr/HzoPoSeXA==
+"@technote-space/github-action-test-helper@^0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.0.24.tgz#c659348513372971d0edb2d91d9e9c53faa15560"
+  integrity sha512-t7yR7nNKAHMBgigTpKI0QiHZZgS0fUmdED2fkzVOLaeGvnuNAzd6M4d7gmcIiWi7NYRYNjFAq0LkNt0vyI7u+w==
   dependencies:
     "@actions/github" "^1.1.0"
+    js-yaml "^3.13.1"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
   dependencies:
     "@actions/github" "^1.1.0"
 
-"@technote-space/github-action-helper@^0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.8.tgz#f332a5966710828b40d854ec54bcffe80f790b27"
-  integrity sha512-oRQfPOQYwkbRfiK6p/ykFKXDetVbcE6BGGI9oRyQ4FjKffUUxQHAqnol8zoEkWliCPO8j+3TDv1bB/1w7Yy1ZQ==
+"@technote-space/github-action-helper@^0.6.9":
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.9.tgz#6e97f2e2c33035446adead23b2606de6ba180447"
+  integrity sha512-17Y+lSZNDH06FLulKti/07f7meIX4W3EtLmsHEM6ljS/aYEWpjIggM2XiLea4r+2faZ8Dwt84VvccXqrKZz+sg==
   dependencies:
     "@actions/core" "^1.2.0"
     "@actions/github" "^1.1.0"
@@ -1295,10 +1295,10 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.1.tgz#269ccccec3ef60ab32358a44d147ac209154b919"
-  integrity sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==
+eslint@^6.7.2:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.2.tgz#c17707ca4ad7b2d8af986a33feba71e18a9fecd1"
+  integrity sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,17 +364,17 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@technote-space/filter-github-action@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@technote-space/filter-github-action/-/filter-github-action-0.1.10.tgz#bdc84a7cf7c2b43be0da91700c436f7ad8c3acb9"
-  integrity sha512-OvOLth0YjnEOTMZbCzyuce8nhtNrCGP3gIyPdy8Jgdz53XwSeQFV0i273BWAxedJ+iqa4kolPXrhHKd1B4ovtg==
+"@technote-space/filter-github-action@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@technote-space/filter-github-action/-/filter-github-action-0.1.11.tgz#436af07a5dd0fa01fd0596eef5a50552a21a7cf7"
+  integrity sha512-Ywyrv0U15vpdw5vS/E3GdibqQozHz5o05hH73cErB6CJOlkx8X4cQRcKxYUNbN2K4r+y24ccOmnVK+/YsGydFQ==
   dependencies:
     "@actions/github" "^1.1.0"
 
-"@technote-space/github-action-helper@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.0.tgz#fe7514ef6970326fb59a4bdd512e6707350e42f3"
-  integrity sha512-xPB1+CE21hApIh1kMp+X4bFr3oZbjgLwQ+w69Cxwm+DuBwnxtVttMsOKrCZ83HF4lR5rFXhGZAbfwe5xf9ewvg==
+"@technote-space/github-action-helper@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-0.6.4.tgz#a85f580f8474a7e1c1e69979f4146e9991baf512"
+  integrity sha512-RkDNz/MIWa1pShCYPJS+dm6KhPav3BcogVJdSqo+jEo4muZrbpvp2cvsoiJQcp6BAOFa9hK+9Am79B9Sq4pGHQ==
   dependencies:
     "@actions/core" "^1.2.0"
     "@actions/github" "^1.1.0"
@@ -557,9 +557,9 @@ acorn@^5.5.3:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
+  integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
 acorn@^7.1.0:
   version "7.1.0"
@@ -721,9 +721,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
+  integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -3496,9 +3496,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.0.tgz#e879eb397efb40511056ede7300b6ac28c51290b"
-  integrity sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
+  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
## Base PullRequest

default branch (https://github.com/technote-space/assign-author/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>sudo yarn global add npm-check-updates</em></summary>

```Shell
yarn global v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "npm-check-updates@3.2.2" with binaries:
      - npm-check-updates
      - ncu
Done in 5.40s.
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/assign-author/assign-author/package.json

 @technote-space/github-action-test-helper  ^0.0.22  →  ^0.0.24 

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 13.13s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 370 new dependencies.
info Direct dependencies
├─ @technote-space/filter-github-action@0.1.10
├─ @technote-space/github-action-helper@0.6.0
├─ @technote-space/github-action-test-helper@0.0.24
├─ @types/jest@24.0.23
├─ @types/node@12.12.12
├─ @typescript-eslint/eslint-plugin@2.8.0
├─ @typescript-eslint/parser@2.8.0
├─ eslint@6.7.0
├─ jest-circus@24.9.0
├─ jest@24.9.0
├─ nock@11.7.0
├─ ts-jest@24.2.0
└─ typescript@3.7.2
info All dependencies
├─ @babel/generator@7.7.4
├─ @babel/helper-function-name@7.7.4
├─ @babel/helper-get-function-arity@7.7.4
├─ @babel/helper-split-export-declaration@7.7.4
├─ @babel/helpers@7.7.4
├─ @babel/highlight@7.5.0
├─ @babel/parser@7.7.4
├─ @babel/plugin-syntax-object-rest-spread@7.7.4
├─ @cnakazawa/watch@1.0.3
├─ @jest/core@24.9.0
├─ @jest/reporters@24.9.0
├─ @jest/source-map@24.9.0
├─ @jest/test-sequencer@24.9.0
├─ @octokit/endpoint@5.5.1
├─ @octokit/graphql@2.1.3
├─ @octokit/request-error@1.2.0
├─ @octokit/request@5.3.1
├─ @octokit/rest@16.35.0
├─ @technote-space/filter-github-action@0.1.10
├─ @technote-space/github-action-helper@0.6.0
├─ @technote-space/github-action-test-helper@0.0.24
├─ @types/babel__core@7.1.3
├─ @types/babel__generator@7.6.0
├─ @types/babel__template@7.0.2
├─ @types/babel__traverse@7.0.8
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/istanbul-lib-report@1.1.1
├─ @types/istanbul-reports@1.1.1
├─ @types/jest@24.0.23
├─ @types/json-schema@7.0.3
├─ @types/node@12.12.12
├─ @types/stack-utils@1.0.1
├─ @types/yargs-parser@13.1.0
├─ @typescript-eslint/eslint-plugin@2.8.0
├─ @typescript-eslint/parser@2.8.0
├─ acorn-globals@4.3.4
├─ acorn-jsx@5.1.0
├─ acorn-walk@6.2.0
├─ acorn@7.1.0
├─ ajv@6.10.2
├─ ansi-regex@4.1.0
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-equal@1.0.0
├─ asn1@0.2.4
├─ assertion-error@1.1.0
├─ assign-symbols@1.0.0
├─ async-limiter@1.0.1
├─ asynckit@0.4.0
├─ atob-lite@2.0.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.8.0
├─ babel-jest@24.9.0
├─ babel-plugin-jest-hoist@24.9.0
├─ babel-preset-jest@24.9.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ before-after-hook@2.1.0
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ browser-process-hrtime@0.1.3
├─ browser-resolve@1.11.3
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ btoa-lite@1.0.0
├─ buffer-from@1.1.1
├─ cache-base@1.0.1
├─ camelcase@5.3.1
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ chai@4.2.0
├─ chardet@0.7.0
├─ check-error@1.0.2
├─ ci-info@2.0.0
├─ class-utils@0.3.6
├─ cli-cursor@3.1.0
├─ cli-width@2.2.0
├─ cliui@5.0.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ commander@2.20.3
├─ concat-map@0.0.1
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-util-is@1.0.2
├─ cross-spawn@6.0.5
├─ cssom@0.3.8
├─ cssstyle@1.4.0
├─ dashdash@1.14.1
├─ data-urls@1.1.0
├─ decamelize@1.2.0
├─ decode-uri-component@0.2.0
├─ deep-eql@3.0.1
├─ deep-is@0.1.3
├─ delayed-stream@1.0.0
├─ detect-newline@2.1.0
├─ diff-sequences@24.9.0
├─ doctrine@3.0.0
├─ domexception@1.0.1
├─ ecc-jsbn@0.1.2
├─ emoji-regex@7.0.3
├─ end-of-stream@1.4.4
├─ error-ex@1.3.2
├─ es-abstract@1.16.0
├─ es-to-primitive@1.2.1
├─ escodegen@1.12.0
├─ eslint@6.7.0
├─ espree@6.1.2
├─ esprima@4.0.1
├─ esquery@1.0.1
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ external-editor@3.1.0
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@2.0.1
├─ fast-levenshtein@2.0.6
├─ figures@3.1.0
├─ file-entry-cache@5.0.1
├─ fill-range@4.0.0
├─ flat-cache@2.0.1
├─ flatted@2.0.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ get-caller-file@2.0.5
├─ get-func-name@2.0.0
├─ get-stream@4.1.0
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ glob-parent@5.1.0
├─ glob@7.1.6
├─ globals@12.3.0
├─ graceful-fs@4.2.3
├─ growly@1.3.0
├─ handlebars@4.5.3
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-symbols@1.0.1
├─ has-value@1.0.0
├─ has@1.0.3
├─ hosted-git-info@2.8.5
├─ html-encoding-sniffer@1.0.2
├─ http-signature@1.2.0
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ inquirer@7.0.0
├─ invariant@2.2.4
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.1
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@2.0.0
├─ is-plain-object@2.0.4
├─ is-promise@2.1.0
├─ is-regex@1.0.4
├─ is-stream@1.1.0
├─ is-symbol@1.0.3
├─ is-typedarray@1.0.0
├─ is-windows@1.0.2
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isstream@0.1.2
├─ istanbul-lib-instrument@3.3.0
├─ istanbul-lib-report@2.0.8
├─ istanbul-lib-source-maps@3.0.6
├─ istanbul-reports@2.2.6
├─ jest-changed-files@24.9.0
├─ jest-circus@24.9.0
├─ jest-cli@24.9.0
├─ jest-docblock@24.9.0
├─ jest-environment-jsdom@24.9.0
├─ jest-environment-node@24.9.0
├─ jest-leak-detector@24.9.0
├─ jest-pnp-resolver@1.2.1
├─ jest-resolve-dependencies@24.9.0
├─ jest-serializer@24.9.0
├─ jest-watcher@24.9.0
├─ jest@24.9.0
├─ js-tokens@4.0.0
├─ jsdom@11.12.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.1
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ left-pad@1.3.0
├─ leven@3.1.0
├─ levn@0.3.0
├─ load-json-file@4.0.0
├─ locate-path@3.0.0
├─ lodash.get@4.4.2
├─ lodash.memoize@4.1.2
├─ lodash.set@4.3.2
├─ lodash.unescape@4.0.1
├─ lodash.uniq@4.5.0
├─ loose-envify@1.4.0
├─ macos-release@2.3.0
├─ make-error@1.3.5
├─ makeerror@1.0.11
├─ map-visit@1.0.0
├─ merge-stream@2.0.0
├─ mime-db@1.42.0
├─ mime-types@2.1.25
├─ mimic-fn@2.1.0
├─ minimatch@3.0.4
├─ mixin-deep@1.3.2
├─ mkdirp@0.5.1
├─ ms@2.1.2
├─ mute-stream@0.0.8
├─ nanomatch@1.2.13
├─ neo-async@2.6.1
├─ nice-try@1.0.5
├─ nock@11.7.0
├─ node-fetch@2.6.0
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@5.4.3
├─ normalize-package-data@2.5.0
├─ normalize-path@2.1.1
├─ npm-run-path@2.0.2
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-inspect@1.7.0
├─ object-keys@1.1.1
├─ object.getownpropertydescriptors@2.0.3
├─ octokit-pagination-methods@1.1.0
├─ onetime@5.1.0
├─ optimist@0.6.1
├─ optionator@0.8.3
├─ os-name@3.1.0
├─ os-tmpdir@1.0.2
├─ p-each-series@1.0.0
├─ p-finally@1.0.0
├─ p-limit@2.2.1
├─ p-locate@3.0.0
├─ p-reduce@1.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse-json@4.0.0
├─ parse5@4.0.0
├─ pascalcase@0.1.1
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@3.0.0
├─ pathval@1.1.0
├─ performance-now@2.1.0
├─ pirates@4.0.1
├─ pkg-dir@3.0.0
├─ pn@1.1.0
├─ posix-character-classes@0.1.1
├─ progress@2.0.3
├─ prompts@2.3.0
├─ propagate@2.0.1
├─ psl@1.4.0
├─ pump@3.0.0
├─ qs@6.5.2
├─ react-is@16.12.0
├─ read-pkg-up@4.0.0
├─ read-pkg@3.0.0
├─ regexpp@2.0.1
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.3
├─ request-promise-native@1.0.8
├─ request@2.88.0
├─ require-directory@2.1.1
├─ resolve-cwd@2.0.0
├─ resolve-from@4.0.0
├─ resolve-url@0.2.1
├─ resolve@1.12.2
├─ restore-cursor@3.1.0
├─ ret@0.1.15
├─ rimraf@2.7.1
├─ rsvp@4.8.5
├─ run-async@2.3.0
├─ rxjs@6.5.3
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ sax@1.2.4
├─ semver@5.7.1
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ shellwords@0.1.1
├─ signal-exit@3.0.2
├─ sisteransi@1.0.4
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.2
├─ source-map-support@0.5.16
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.0
├─ spdx-exceptions@2.2.0
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string.prototype.trimleft@2.1.0
├─ string.prototype.trimright@2.1.0
├─ strip-eof@1.0.0
├─ strip-json-comments@3.0.1
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ test-exclude@5.2.3
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmp@0.0.33
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ ts-jest@24.2.0
├─ tslib@1.10.0
├─ tunnel-agent@0.6.0
├─ tweetnacl@0.14.5
├─ type-detect@4.0.8
├─ typescript@3.7.2
├─ uglify-js@3.6.9
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use@3.1.1
├─ util.promisify@1.0.0
├─ uuid@3.3.3
├─ v8-compile-cache@2.1.0
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ w3c-hr-time@1.0.1
├─ walker@1.0.7
├─ whatwg-encoding@1.0.5
├─ whatwg-mimetype@2.3.0
├─ whatwg-url@6.5.0
├─ which-module@2.0.0
├─ which@1.3.1
├─ windows-release@3.2.0
├─ word-wrap@1.2.3
├─ wordwrap@0.0.3
├─ wrap-ansi@5.1.0
├─ write-file-atomic@2.4.1
├─ write@1.0.3
├─ ws@5.2.2
├─ xml-name-validator@3.0.0
├─ y18n@4.0.0
└─ yargs-parser@10.1.0
Done in 5.97s.
```

### stderr:

```Shell
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > left-pad@1.3.0: use String.prototype.padStart()
warning jest > jest-cli > @jest/core > jest-haste-map > fsevents@1.2.9: One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.19.1
0 vulnerabilities found - Packages audited: 892065
Done in 0.98s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)